### PR TITLE
complementing with traffic load related definition and patterns

### DIFF
--- a/draft-ietf-bmwg-powerbench.xml
+++ b/draft-ietf-bmwg-powerbench.xml
@@ -157,13 +157,8 @@
       (also known as "longitudinal" or "self-referential" benchmarking).</t>
 	</list></t>
 
-<<<<<<< Updated upstream
-    <t>Achieving either objective requires a well-defined set of principles prescribing
-    what must be measured, how it must be measured, and which results must be reported. 
-=======
     <t>Achieving any of these objectives requires a well-defined set of principles prescribing
     what must be measured, how must be measured, and which results must be reported. 
->>>>>>> Stashed changes
     Providing those principles is the objective of this draft.
     These are simply called "the benchmark" in the rest of this draft.</t>
 
@@ -228,15 +223,9 @@
 
     <t>Issues<list>
       <t>The traffic loads and the weighted multipliers need to be clearly established a priori.</t>
-<<<<<<< Updated upstream
-      <t>It is unclear if the definition of the Ti's is/should be linked to the traffic load levels. 
-      For a given port configuration (which MAY result in 50% of the total capacity a device can provide), 
-      one MAY be interested in traffic load of e.g., 5% or 10% or the total capacity (not only 50%).</t>
-=======
       <t>It is unclear if the definition of the Ti is/should be linked to the traffic load levels. 
       For a given port configuration (which may result in 50% of the total capacity a device can provide), 
       one may be interested in traffic load of e.g., 5% or 10% or the total capacity (not only 50%).</t>
->>>>>>> Stashed changes
     </list></t>
 
     <t>See Also:<list><t><xref target="ETSI-ES-203-136" />,<xref target="ITUT-L.1310" />
@@ -263,20 +252,11 @@
       <t>The traffic loads and the weighted multipliers need to be clearly established a priori.</t>
       <t>Importantly, the traffic MUST be forwarded of the correct port! 
       It would be easy to cut power down by dropping all traffic, and, naturally, we do not want that.
-<<<<<<< Updated upstream
-      A tolerance on packet loss and/or forwarding error MUST be specified somehow.  That tolerance could
-      be zero for some benchmark problems (e.g., Non packet loss (NDR) estimation), and non-zero for others.
-      Tolerating some errors MAY be interesting to navigate the design space of energy saving techniques,
-      such as approximate computing/routing. According to measurement procedure in section 6.5 of 
-      <xref target="ATIS-0600015.03.2013" />, the Equipment Unit Test (EUT) SHOULD be able to return to full NDR load. 
-=======
       A tolerance on packet loss and/or forwarding error must be specified somehow.  That tolerance could
       be zero for some benchmark problems (e.g., Non-Drop Rate (NDR) estimation), and non-zero for others.
       Tolerating some errors may be interesting to navigate the design space of energy saving techniques,
       such as approximate computing/routing. According to measurement procedure in section 6.5 of 
-      <xref target="ATIS-0600015.03.2013" />, the Equipment Under Test (EUT) should be able to return to full NDR load. 
->>>>>>> Stashed changes
-      Failure to do so disqualifies the test results. </t>
+      <xref target="ATIS-0600015.03.2013" />, the Equipment Under Test (EUT) should be able to return to full NDR load. Failure to do so disqualifies the test results. </t>
     </list></t>
 
     <t>See Also:<list><t><xref target="ETSI-ES-203-136" />,<xref target="ITUT-L.1310" />
@@ -301,8 +281,8 @@
 	 <t>Measurement units:<list><t>Gbps/Watt.</t></list></t>
 
      <t>Issues:<list>
-      <t>The traffic loads  and the weighted multipliers need to be clearly established a priori.</t>
-      <t>There are other approaches defined in ITU-T and ATIS that leverage the total capacity of the interfaces (T) which is the sum of all interface throughputs and is not linked to traffic load levels. This result EER is a scaled value proportional to the EER using the total weighted capacity of the interfaces (T)</t>
+      <t>The traffic loads and the weighted multipliers need to be clearly established a priori.</t>
+      <t>Optionally the total capacity of the interfaces (T) can be used in replacement of the total weighted capacity of the interfaces. The former is the sum of all interface throughputs and is not linked to traffic load levels. This result EER is a scaled value proportional to the EER using the total weighted capacity of the interfaces (T)</t>
      </list></t>
 
      <t>See Also:<list><t><xref target="ETSI-ES-203-136" />,<xref target="ITUT-L.1310" />
@@ -467,15 +447,10 @@
     and settings need to be specified.</t>
 
     <t hangText="Port Utilization:"><br />  For each test the port utilization of each port 
-<<<<<<< Updated upstream
     MUST be specified.  The actual traffic load can use the information 
-    defined in <xref target="RFC2544" />.</t>
-=======
-    must be specified.  The actual traffic load can use the information 
     defined in <xref target="RFC2544" />. To characterize power consumption under realistic 
     traffic conditions, the actual traffic load can use variable 
     packet size distributions as specified in <xref target="RFC6985" />.</t>
->>>>>>> Stashed changes
 
     <t hangText="Traffic trace:"><br />  For each test, the traffic trace used (amongst those 
     prescribed by the benchmark) MUST be specified.</t>

--- a/draft-ietf-bmwg-powerbench.xml
+++ b/draft-ietf-bmwg-powerbench.xml
@@ -147,14 +147,23 @@
 	
     <section title="Aim and Scope">
 
-    <t>Benchmarking can be understood to serve two related but different objectives:<list>
-	 <t>Assessing "which system performs best" over a set of well-defined scenarios.</t>
+    <t>Benchmarking can be understood to serve three related but different objectives:<list>
+	   <t>Assessing "which system performs best" over a set of well-defined scenarios.</t>
      <t>Measuring the contribution of sub-systems to the overall system's performance
 	 (also known as "micro-benchmark").</t>
+     <t>Evaluating the evolution of a system's energy consumption 
+      profile against its own historical baseline to assess the impact 
+      of software updates, feature activation, or operational aging 
+      (also known as "longitudinal" or "self-referential" benchmarking).</t>
 	</list></t>
 
+<<<<<<< Updated upstream
     <t>Achieving either objective requires a well-defined set of principles prescribing
     what must be measured, how it must be measured, and which results must be reported. 
+=======
+    <t>Achieving any of these objectives requires a well-defined set of principles prescribing
+    what must be measured, how must be measured, and which results must be reported. 
+>>>>>>> Stashed changes
     Providing those principles is the objective of this draft.
     These are simply called "the benchmark" in the rest of this draft.</t>
 
@@ -169,7 +178,7 @@
 
      <t>Replicability is defined as achieving the same results with newly collected data.
      Formally, it is a pre-requisite for benchmarking. Benchmark results are meant to
-     be compared, and this comparison is not sound is the individual results are not replicable.</t>
+     be compared, and this comparison is not sound if the individual results are not replicable.</t>
 
      <t>As discussed later in this draft, replicability in power measurements is complex
      as power is affected by a wide range of parameters, some of which are hard to control 
@@ -219,9 +228,15 @@
 
     <t>Issues<list>
       <t>The traffic loads and the weighted multipliers need to be clearly established a priori.</t>
+<<<<<<< Updated upstream
       <t>It is unclear if the definition of the Ti's is/should be linked to the traffic load levels. 
       For a given port configuration (which MAY result in 50% of the total capacity a device can provide), 
       one MAY be interested in traffic load of e.g., 5% or 10% or the total capacity (not only 50%).</t>
+=======
+      <t>It is unclear if the definition of the Ti is/should be linked to the traffic load levels. 
+      For a given port configuration (which may result in 50% of the total capacity a device can provide), 
+      one may be interested in traffic load of e.g., 5% or 10% or the total capacity (not only 50%).</t>
+>>>>>>> Stashed changes
     </list></t>
 
     <t>See Also:<list><t><xref target="ETSI-ES-203-136" />,<xref target="ITUT-L.1310" />
@@ -248,11 +263,19 @@
       <t>The traffic loads and the weighted multipliers need to be clearly established a priori.</t>
       <t>Importantly, the traffic MUST be forwarded of the correct port! 
       It would be easy to cut power down by dropping all traffic, and, naturally, we do not want that.
+<<<<<<< Updated upstream
       A tolerance on packet loss and/or forwarding error MUST be specified somehow.  That tolerance could
       be zero for some benchmark problems (e.g., Non packet loss (NDR) estimation), and non-zero for others.
       Tolerating some errors MAY be interesting to navigate the design space of energy saving techniques,
       such as approximate computing/routing. According to measurement procedure in section 6.5 of 
       <xref target="ATIS-0600015.03.2013" />, the Equipment Unit Test (EUT) SHOULD be able to return to full NDR load. 
+=======
+      A tolerance on packet loss and/or forwarding error must be specified somehow.  That tolerance could
+      be zero for some benchmark problems (e.g., Non-Drop Rate (NDR) estimation), and non-zero for others.
+      Tolerating some errors may be interesting to navigate the design space of energy saving techniques,
+      such as approximate computing/routing. According to measurement procedure in section 6.5 of 
+      <xref target="ATIS-0600015.03.2013" />, the Equipment Under Test (EUT) should be able to return to full NDR load. 
+>>>>>>> Stashed changes
       Failure to do so disqualifies the test results. </t>
     </list></t>
 
@@ -264,7 +287,7 @@
     <section title="Energy Efficiency Ratio">	
      <t>Energy Efficiency Ratio (EER) is defined as the throughput forwarded by 1 watt
 	 and it is introduced in <xref target="ETSI-ES-203-136" />. A higher EER corresponds
-	 to a better the energy efficiency.</t>
+	 to a better energy efficiency.</t>
 	 
 	 <t>Definition:<list>
                 <t>EER = T/P</t>
@@ -277,7 +300,10 @@
     
 	 <t>Measurement units:<list><t>Gbps/Watt.</t></list></t>
 
-     <t>Issues:<list><t>The traffic loads  and the weighted multipliers need to be clearly established a priori.</t></list></t>
+     <t>Issues:<list>
+      <t>The traffic loads  and the weighted multipliers need to be clearly established a priori.</t>
+      <t>There are other approaches defined in ITU-T and ATIS that leverage the total capacity of the interfaces (T) which is the sum of all interface throughputs and is not linked to traffic load levels. This result EER is a scaled value proportional to the EER using the total weighted capacity of the interfaces (T)</t>
+     </list></t>
 
      <t>See Also:<list><t><xref target="ETSI-ES-203-136" />,<xref target="ITUT-L.1310" />
       ,<xref target="ATIS-0600015.03.2013" />.</t></list></t>
@@ -441,8 +467,15 @@
     and settings need to be specified.</t>
 
     <t hangText="Port Utilization:"><br />  For each test the port utilization of each port 
+<<<<<<< Updated upstream
     MUST be specified.  The actual traffic load can use the information 
     defined in <xref target="RFC2544" />.</t>
+=======
+    must be specified.  The actual traffic load can use the information 
+    defined in <xref target="RFC2544" />. To characterize power consumption under realistic 
+    traffic conditions, the actual traffic load can use variable 
+    packet size distributions as specified in <xref target="RFC6985" />.</t>
+>>>>>>> Stashed changes
 
     <t hangText="Traffic trace:"><br />  For each test, the traffic trace used (amongst those 
     prescribed by the benchmark) MUST be specified.</t>
@@ -460,10 +493,10 @@
 
      <section title="Throughput">
 
-      <t>Objective:<list><t>To determine the DUT throughput according to <xref target="RFC2544" />.</t></list></t>
+      <t>Objective:<list><t>To determine the DUT throughput according to <xref target="RFC2544" />.
+      And to characterize throughput under realistic traffic patterns using variable packet size distributions as specified in <xref target="RFC6985" />.</t></list></t>
 
-      <t>Procedure:<list><t>The test is done using a multi-port setup as specified in Section 16 and Section 26.1
-      of <xref target="RFC2544" />.</t></list></t>
+      <t>Procedure:<list><t>The test is done using a multi-port setup as specified in Section 16 and Section 26.1 of <xref target="RFC2544" />. To assess throughput under realistic Internet traffic conditions, the test is performed using the IMIX Genome packet size distributions specified in <xref target="RFC6985" />.</t></list></t>
 
       <t>Reporting format:<list><t>The results of the throughput SHOULD be
       reported according to <xref target="report" />.</t></list></t>


### PR DESCRIPTION
Mainly with following optimizations suggested:

1. the benchmark aim lack of self comparison part when it is aimed to compare the same device with software features or pluggble hardware updates which can contribute to energy efficiency metrics, test before and after can show if the effect meets the expectations.
2. the throughput can be weighted throughput as said in the previous draft, still, in the latest itu-t and atis standard, they all use the overall throughput which is proportional to the weighted one so to easy the calculations, so here the overall throughput is suggested to be mentioned as well.
3. For benchmarking test, only 2544 is mentioned, but IMIX traffic load is also widely used in the reality and standards, even widely than 2544, as it is more like real traffic load in practice, so it's suggested to add imix traffic load description besides 2544.
4. some trivial typos optimized.